### PR TITLE
Resolve Unit Tests failed

### DIFF
--- a/KYS.Library/Validations/RequiredIf2Attribute.cs
+++ b/KYS.Library/Validations/RequiredIf2Attribute.cs
@@ -102,8 +102,16 @@ namespace KYS.Library.Validations
 
                 if (isValid)
                 {
-                    if (value == null
-                        || value.ToString() == Activator.CreateInstance(value.GetType()).ToString())
+                    bool isNull = value == null;
+                    bool isEmptyString = value is string str && String.IsNullOrEmpty(str);
+                    bool isValueTypeWithDefault = value != null
+                        && value.GetType().IsValueType
+                        && value.Equals(Activator.CreateInstance(value.GetType()));
+                    bool hasParameterlessConstructor = value?.GetType().GetConstructor(Type.EmptyTypes) != null;
+                    bool matchesDefaultInstance = hasParameterlessConstructor
+                        && value.ToString() == Activator.CreateInstance(value.GetType()).ToString();
+
+                    if (isNull || isEmptyString || isValueTypeWithDefault || (!isValueTypeWithDefault && matchesDefaultInstance))
                         validationResult = new ValidationResult(null, new string[] { validationContext.MemberName });
                 }
             }

--- a/KYS.TestProject/MultiResourcesTranslationServiceUnitTest.cs
+++ b/KYS.TestProject/MultiResourcesTranslationServiceUnitTest.cs
@@ -323,7 +323,7 @@ namespace KYS.TestProject
                 cultureInfo,
                 new List<CultureInfo> { cultureInfo }
             );
-            string input = "spouse";
+            string input = "Spouse";
             //string expectedValue = "คู่สมรส";
             string expectedValue = Helpers.GetTranslatedText(input, resourceType, cultureInfo) ?? input;
 


### PR DESCRIPTION
| KYS.Library |
RequiredIf2Attribute : Resolve No parameterless constructor defined for type 'System.String exception

| KYS.TestProject |
MultiResourcesTranslationServiceUnitTest:
- TranslateSpouseWithSpecificResource fix typo error