### PR TITLE
IConfigurationBuilder support Bind with complex value and Enhancements

### DIFF
--- a/KYS.Library/Extensions/IConfigurationBuilderExtensions.cs
+++ b/KYS.Library/Extensions/IConfigurationBuilderExtensions.cs
@@ -1,0 +1,80 @@
+﻿using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using static KYS.Library.Helpers.JsonHelper;
+
+namespace KYS.Library.Extensions
+{
+    public static class IConfigurationBuilderExtensions
+    {
+        private static readonly JsonSerializer _DefaultSerializer = JsonSerializer.Create(new JsonSerializerSettings
+        {
+            DateFormatHandling = DateFormatHandling.IsoDateFormat,
+            DateTimeZoneHandling = DateTimeZoneHandling.RoundtripKind,
+            DateParseHandling = DateParseHandling.DateTime,
+            DateFormatString = "o", // ISO 8601
+            Culture = CultureInfo.InvariantCulture
+        });
+
+        /// <summary>
+        /// Bind complex value (object/array) to configuration.
+        /// <br /><br />
+        /// Inspired from <a href="https://stackoverflow.com/a/79752367/8017690">IConfiguration Bind doesn't work with arrays</a>.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="configurationBuilder"></param>
+        /// <param name="key"></param>
+        /// <param name="obj"></param>
+        public static void Bind<T>(this IConfigurationBuilder configurationBuilder, string key, T obj)
+        {
+            var dict = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+
+            if (obj is string s)
+            {
+                dict[key] = s;
+            }
+            else if (IsScalarLike(obj.GetType()))
+            {
+                dict[key] = obj.ToInvariantString();
+            }
+            else if (obj is IEnumerable seq)
+            {
+                JToken jToken = JArray.FromObject(seq, _DefaultSerializer);
+                dict = Flatten(jToken, FlattenFormat.DotNet)
+                    .Select(x => new KeyValuePair<string, string?>(
+                        $"{key}:{x.Key}",
+                        x.Value?.ToString()))
+                    .ToDictionary();
+            }
+            else
+            {
+                JToken jToken = JObject.FromObject(obj, _DefaultSerializer);
+                dict = Flatten(jToken, FlattenFormat.DotNet)
+                    .Select(x => new KeyValuePair<string, string?>(
+                        $"{key}:{x.Key}",
+                        x.Value?.ToString()))
+                    .ToDictionary();
+            }
+
+            configurationBuilder.AddInMemoryCollection(dict);
+        }
+
+        private static bool IsScalarLike(Type t)
+        {
+            t = Nullable.GetUnderlyingType(t) ?? t;
+            return t.IsPrimitive
+                   || t.IsEnum
+                   || t == typeof(decimal)
+                   || t == typeof(Guid)
+                   || t == typeof(DateTime)
+                   || t == typeof(DateTimeOffset)
+                   || t == typeof(TimeSpan)
+                   || t == typeof(Uri);
+        }
+    }
+}

--- a/KYS.Library/Extensions/StringExtensions.cs
+++ b/KYS.Library/Extensions/StringExtensions.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 
 namespace KYS.Library.Extensions
 {
@@ -28,11 +31,58 @@ namespace KYS.Library.Extensions
             return str;
         }
 
+        /// <summary>
+        /// Removes first occurrence of the given prefixes from end of the given string.
+        /// Ordering is important. If one of the preFixes is matched, others will not be tested.
+        /// </summary>
+        /// <param name="str">The string.</param>
+        /// <param name="preFixes">one or more prefix.</param>
+        /// <returns>Modified string or the same string if it has not any of given prefixes</returns>
+        public static string RemovePreFix(this string str, params string[] preFixes)
+        {
+            if (String.IsNullOrEmpty(str))
+                return str;
+
+            if (preFixes.IsNullOrEmpty())
+                return str;
+
+            foreach (var preFix in preFixes)
+            {
+                if (str.StartsWith(preFix))
+                    str = str.Substring(1, str.Length - preFix.Length);
+            }
+
+            return str;
+        }
+
         public static bool IsValidBase64(this string str)
         {
             Span<byte> buffer = new Span<byte>(new byte[str.Length]);
 
             return Convert.TryFromBase64String(str, buffer, out _);
+        }
+
+        public static string Join(this IEnumerable<string?> values, string separator, bool isRemoveNullOrEmptyString = true)
+        {
+            if (isRemoveNullOrEmptyString)
+                values = values.Where(x => !String.IsNullOrEmpty(x));
+
+            return String.Join(separator, values);
+        }
+
+        public static string Join(string separator, bool isRemoveNullOrEmptyString = true, params string?[] values)
+        {
+            return values.Join(separator, isRemoveNullOrEmptyString);
+        }
+
+        public static string ToInvariantString(this object? value)
+        {
+            if (value is null)
+                return null;
+
+            return value is IFormattable f
+                ? f.ToString(null, CultureInfo.InvariantCulture)
+                : value.ToString();
         }
     }
 }

--- a/KYS.Library/KYS.Library.csproj
+++ b/KYS.Library/KYS.Library.csproj
@@ -10,6 +10,7 @@
 		<PackageReference Include="itext7" Version="7.2.5" />
 		<PackageReference Include="itext7.pdfhtml" Version="4.0.5" />
 		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.6" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
 		<PackageReference Include="SharpZipLib" Version="1.4.2" />
 		<PackageReference Include="SkiaSharp" Version="2.88.6" />
 		<PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.6" />

--- a/KYS.TestProject/Helpers.cs
+++ b/KYS.TestProject/Helpers.cs
@@ -1,11 +1,25 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
 using System.Globalization;
+using System.IO;
 using System.Resources;
 
 namespace KYS.TestProject
 {
     public static class Helpers
     {
+        private static readonly JsonSerializer DefaultSerializer = JsonSerializer.Create(
+            new JsonSerializerSettings
+            {
+                DateFormatHandling = DateFormatHandling.IsoDateFormat,
+                DateTimeZoneHandling = DateTimeZoneHandling.RoundtripKind,
+                DateParseHandling = DateParseHandling.DateTime,
+                DateFormatString = "o", // ISO 8601
+                Culture = CultureInfo.InvariantCulture,
+                Converters = { new IsoDateTimeConverter() }
+            });
+
         public static string GetTranslatedText(string input, Type resourceType, CultureInfo cultureInfo)
         {
             ResourceManager resourceManager = new ResourceManager(resourceType);
@@ -13,6 +27,17 @@ namespace KYS.TestProject
             ResourceSet rs = resourceManager.GetResourceSet(cultureInfo, true, false);
 
             return rs.GetObject(input)?.ToString();
+        }
+
+        public static string SerializeJson(object obj)
+        {
+            StringWriter stringWriter = new StringWriter();
+            using (JsonTextWriter jsonWriter = new JsonTextWriter(stringWriter))
+            {
+                DefaultSerializer.Serialize(jsonWriter, obj);
+            }
+
+            return stringWriter.ToString();
         }
     }
 }

--- a/KYS.TestProject/IConfigurationBuilderBindUnitTest.cs
+++ b/KYS.TestProject/IConfigurationBuilderBindUnitTest.cs
@@ -1,0 +1,278 @@
+﻿using KYS.Library.Extensions;
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace KYS.TestProject
+{
+    internal class IConfigurationBuilderBindUnitTest
+    {
+        private IConfiguration _configuration;
+
+        private const string AppName = "AppName";
+        private const string RetryCount = "RetryCount";
+        private const string Features = "Features";
+        private const string Cultures = "Cultures";
+        private const string Users = "Users";
+
+        private IConfiguration LoadConfiguration()
+        {
+            return new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: false)
+                .Build();
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            _configuration = LoadConfiguration();
+        }
+
+        [Test]
+        public void CanBindScalarValues()
+        {
+            // Arrange
+            var oldAppName = _configuration[AppName];
+            var oldRetryCount = int.Parse(_configuration[RetryCount] ?? "0");
+
+            var configValue = new
+            {
+                AppName = "NewMyTestApp",
+                RetryCount = 3
+            };
+
+            // Act
+            var config = new ConfigurationBuilder();
+
+            config.Bind(AppName, configValue.AppName);
+            config.Bind(RetryCount, configValue.RetryCount);
+
+            var configRoot = config.Build();
+
+            // Assert
+            string newAppName = configRoot[AppName];
+            int newRetryCount = int.Parse(configRoot[RetryCount] ?? "0");
+
+            Assert.AreNotEqual(oldAppName, newAppName);
+            Assert.AreNotEqual(oldRetryCount, newRetryCount);
+
+            Assert.AreEqual(configValue.AppName, newAppName);
+            Assert.AreEqual(configValue.RetryCount, newRetryCount);
+        }
+
+        [Test]
+        public void CanBindObject()
+        {
+            // Arrange
+            var oldFeatures = _configuration.GetSection(Features).Get<FeaturesConfig>();
+
+            var configValue = new FeaturesConfig
+            {
+                EnableLogging = true,
+                MaxItems = 10
+            };
+
+            // Act
+            var config = new ConfigurationBuilder();
+
+            config.Bind(Features, configValue);
+
+            var configRoot = config.Build();
+
+            // Assert
+            var newFeatures = configRoot.GetSection(Features).Get<FeaturesConfig>();
+
+            Assert.AreNotEqual(oldFeatures.EnableLogging, newFeatures.EnableLogging);
+            Assert.AreNotEqual(oldFeatures.MaxItems, newFeatures.MaxItems);
+
+            Assert.AreEqual(configValue.EnableLogging, newFeatures.EnableLogging);
+            Assert.AreEqual(configValue.MaxItems, newFeatures.MaxItems);
+        }
+
+        [Test]
+        public void CanBindArray()
+        {
+            // Arrange
+            var oldCultures = _configuration.GetSection(Cultures).Get<List<string>>();
+
+            var configValue = new string[] { "en-US", "es-ES", "zh-CN" };
+
+            // Act
+            var config = new ConfigurationBuilder();
+
+            config.Bind(Cultures, configValue);
+
+            var configRoot = config.Build();
+
+            // Assert
+            var newCultures = configRoot.GetSection(Cultures).Get<List<string>>();
+
+            Assert.AreEqual(newCultures[0], configValue[0]);
+            Assert.AreEqual(newCultures[1], configValue[1]);
+            Assert.AreEqual(newCultures[2], configValue[2]);
+        }
+
+        [Test]
+        public void CanBindArrayOfObjects()
+        {
+            // Arrange
+            var oldUsers = _configuration.GetSection(Users).Get<List<UserConfig>>();
+
+            var configValue = new UserConfig
+            {
+                Name = "Charles",
+                Age = 27
+            };
+
+            // Act
+            var config = new ConfigurationBuilder();
+
+            oldUsers[1].Name = configValue.Name;
+            oldUsers[1].Age = configValue.Age;
+
+            config.Bind(Users, oldUsers);
+
+            var configRoot = config.Build();
+
+            // Assert
+            var newUsers = configRoot.GetSection(Users).Get<List<UserConfig>>();
+
+            Assert.AreEqual(oldUsers[0].Name, newUsers[0].Name);
+            Assert.AreEqual(oldUsers[0].Age, newUsers[0].Age);
+
+            Assert.AreEqual(configValue.Name, newUsers[1].Name);
+            Assert.AreEqual(configValue.Age, newUsers[1].Age);
+        }
+
+        [Test]
+        public void CanBindArrayOfObjectsAndSetEmploymentInfo()
+        {
+            // Arrange
+            var oldUsers = _configuration.GetSection(Users).Get<List<UserConfig>>();
+
+            var configValueForAlice = new EmploymentInfo
+            {
+                JoinedDate = new DateTime(2025, 3, 1),
+                LastDate = new DateTime(2025, 6, 1),
+                Department = "HR",
+                EmploymentType = EmploymentType.PartTime,
+                Position = "Intern",
+                Salary = 2000
+            };
+
+            var configValueForBob = new EmploymentInfo
+            {
+                JoinedDate = new DateTime(2025, 1, 1),
+                Department = "Tech",
+                EmploymentType = EmploymentType.Permanent,
+                Position = "Software Dev",
+                Salary = 5000
+            };
+
+            // Act
+            var config = new ConfigurationBuilder();
+
+            oldUsers[0].EmploymentInfo = configValueForAlice;
+            oldUsers[1].EmploymentInfo = configValueForBob;
+
+            config.Bind(Users, oldUsers);
+
+            var configRoot = config.Build();
+
+            // Assert
+            var newUsers = configRoot.GetSection(Users).Get<List<UserConfig>>();
+
+            var settings = new JsonSerializerSettings
+            {
+                DateFormatHandling = DateFormatHandling.IsoDateFormat,
+                DateParseHandling = DateParseHandling.DateTime,
+                Culture = System.Globalization.CultureInfo.InvariantCulture,
+                Converters = { new IsoDateTimeConverter() }
+            };
+            Assert.AreEqual(
+                Helpers.SerializeJson(configValueForAlice),
+                Helpers.SerializeJson(newUsers[0].EmploymentInfo));
+            Assert.AreEqual(
+                Helpers.SerializeJson(configValueForBob),
+                Helpers.SerializeJson(newUsers[1].EmploymentInfo));
+        }
+
+        [Test]
+        public void CanBindArrayOfObjectsAndAddContacts()
+        {
+            // Arrange
+            var oldUsers = _configuration.GetSection(Users).Get<List<UserConfig>>();
+
+            var configValue = new Contact
+            {
+                ContactNumber = "123456",
+                ContactType = "Mobile"
+            };
+
+            // Act
+            var config = new ConfigurationBuilder();
+
+            oldUsers[0].Contacts = new List<Contact>();
+            oldUsers[0].Contacts.Add(configValue);
+
+            config.Bind(Users, oldUsers);
+
+            var configRoot = config.Build();
+
+            // Assert
+            var newUsers = configRoot.GetSection(Users).Get<List<UserConfig>>();
+
+            Assert.AreEqual(oldUsers[0].Name, newUsers[0].Name);
+            Assert.AreEqual(oldUsers[0].Age, newUsers[0].Age);
+
+            Assert.AreEqual(1, newUsers[0].Contacts.Count);
+            Assert.AreEqual(configValue.ContactType, newUsers[0].Contacts[0].ContactType);
+            Assert.AreEqual(configValue.ContactNumber, newUsers[0].Contacts[0].ContactNumber);
+        }
+
+        private class FeaturesConfig
+        {
+            public bool EnableLogging { get; set; }
+            public int MaxItems { get; set; }
+        }
+
+        private class UserConfig
+        {
+            public string Name { get; set; }
+            public int Age { get; set; }
+            public List<Contact> Contacts { get; set; }
+            public EmploymentInfo EmploymentInfo { get; set; }
+        }
+
+        private class Contact
+        {
+            public string ContactNumber { get; set; }
+            public string ContactType { get; set; }
+        }
+
+        private class EmploymentInfo
+        {
+            public DateTime JoinedDate { get; set; }
+            public DateTime? LastDate { get; set; }
+            public EmploymentType EmploymentType { get; set; }
+            public decimal Salary { get; set; }
+            public string Position { get; set; }
+            public string Department { get; set; }
+        }
+
+        private enum EmploymentType
+        {
+            Permanent,
+            PartTime,
+            Contract
+        }
+    }
+}

--- a/KYS.TestProject/KYS.TestProject.csproj
+++ b/KYS.TestProject/KYS.TestProject.csproj
@@ -7,11 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="appsettings.json" />
     <None Remove="Resources\logo.png" />
     <None Remove="Resources\sample.txt" />
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Resources\logo.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/KYS.TestProject/appsettings.json
+++ b/KYS.TestProject/appsettings.json
@@ -1,0 +1,19 @@
+{
+  "AppName": "MyTestApp",
+  "RetryCount": 5,
+  "Features": {
+    "EnableLogging": false,
+    "MaxItems": 100
+  },
+  "Users": [
+    {
+      "Name": "Alice",
+      "Age": 30
+    },
+    {
+      "Name": "Bob",
+      "Age": 25
+    }
+  ],
+  "Cultures": ["en-US", "zh-CN"]
+}


### PR DESCRIPTION
- IConfigurationBuilder extensions support Bind with complex value (object, array)
- StringExtensions:
  * Join (exclude null/empty string)
  * Remove prefix
- JsonHelper:
  * Bug fix: unable to flatten array of scalar type
  * Support flatten formats: C#/.Net, JS, JsonPath (default)
- Unit test for IConfiguration.Bind